### PR TITLE
Use READMEs for package long-descriptions

### DIFF
--- a/accelerate/README.txt
+++ b/accelerate/README.txt
@@ -1,1 +1,4 @@
-This is the Cython-coded accelerator module for PyOpenGL 3.x
+Acceleration code for PyOpenGL
+
+This set of C (Cython) extensions provides acceleration of common operations
+for slow points in PyOpenGL 3.x

--- a/accelerate/setup.py
+++ b/accelerate/setup.py
@@ -15,6 +15,8 @@ else:
 import sys, os
 
 HERE = os.path.normpath(os.path.abspath(os.path.dirname( __file__ )))
+with open(os.path.join(HERE, 'README.txt'), 'r') as f:
+    long_description = f.read()
 
 version = None
 # get version from __init__.py
@@ -114,10 +116,8 @@ if __name__ == "__main__":
             """Intended Audience :: Developers""",
         ],
         'keywords': 'PyOpenGL,accelerate,Cython',
-        'long_description' : """Acceleration code for PyOpenGL
-
-This set of C (Cython) extensions provides acceleration of common operations
-for slow points in PyOpenGL 3.x.""",
+        'long_description' : long_description,
+        'long_description_content_type' : 'text/plain',
         'platforms': ['Win32','Linux','OS-X','Posix'],
     }
     ### Now the actual set up call

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ try:
 except ImportError:
     from distutils.core import setup
 
+HERE = os.path.normpath(os.path.abspath(os.path.dirname( __file__ )))
+with open(os.path.join(HERE, 'readme.rst'), 'r') as f:
+    long_description = f.read()
+
 sys.path.insert(0, '.' )
 metadata = dict(
     version = [
@@ -29,6 +33,8 @@ metadata = dict(
         """Topic :: Software Development :: Libraries :: Python Modules""",
         """Intended Audience :: Developers""",
     ],
+    long_description = long_description,
+    long_description_content_type = 'text/x-rst',
 )
 
 def is_package( path ):


### PR DESCRIPTION
Currently, the PyOpenGL distribution does not have a long-description, and is unhelpful to those who visit the [PyPI package page](https://pypi.org/project/PyOpenGL/). This PR has both PyOpenGL and PyOpenGL-accelerate use their respective README files to generate the long-description.