### PR TITLE
Fix AttributeError in glGetTexImage

### DIFF
--- a/OpenGL/GL/images.py
+++ b/OpenGL/GL/images.py
@@ -235,7 +235,7 @@ def _get_texture_level_dims(target,level):
         GL_1_1.glGetTexLevelParameteriv( target, level, GL_1_1.GL_TEXTURE_HEIGHT, dim )
         dims.append( dim.value )
         if target != GL_1_1.GL_TEXTURE_2D:
-            GL_1_1.glGetTexLevelParameteriv( target, level, GL_1_1.GL_TEXTURE_DEPTH, dim )
+            GL_1_1.glGetTexLevelParameteriv( target, level, GL_1_2.GL_TEXTURE_DEPTH, dim )
             dims.append( dim.value )
     return dims
 


### PR DESCRIPTION
This PR proposes a fix for `glGetTexImage` leading to `AttributeError` when used with `GL_TEXTURE_3D` target.

closes #49