### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ metadata = dict(
     author = 'Mike C. Fletcher',
     author_email = 'mcfletch@vrplumber.com',
     url = 'http://pyopengl.sourceforge.net',
+    project_urls = {
+        'Source': 'https://github.com/mcfletch/pyopengl',
+    },
     license = 'BSD',
     download_url = "http://sourceforge.net/projects/pyopengl/files/PyOpenGL/",
     keywords = 'Graphics,3D,OpenGL,GLU,GLUT,GLE,GLX,EXT,ARB,Mesa,ctypes',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)