### PR TITLE
Fix numpy_formathandler import error

### DIFF
--- a/accelerate/setup.py
+++ b/accelerate/setup.py
@@ -145,5 +145,8 @@ if __name__ == "__main__":
             'OpenGL_accelerate':'OpenGL_accelerate',
         },
         ext_modules=extensions,
+        install_requires = [
+            "numpy"
+        ],
         **extraArguments
     )


### PR DESCRIPTION
When attempting to install from source using a `requirements.txt` file like this
```
numpy
git+https://github.com/mcfletch/pyopengl.git
git+https://github.com/mcfletch/pyopengl.git#subdirectory=accelerate
```
even though numpy is specified before, pip will flat out ignore it and install it afterwards, resulting in the accelerate extension being installed without numpy present and in the end you get the infamous and very annoying message
```
Unable to load numpy_formathandler accelerator from OpenGL_accelerate
```
at every `OpenGL` import, without an easy way to hide it.


This PR simply adds `numpy` as an install dependency for the accelerate extension to avoid this very annoying issue.