### PR TITLE
Build with PEP 517, move project metadata to setup.cfg

### DIFF
--- a/accelerate/pyproject.toml
+++ b/accelerate/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = [ "setuptools >= 42.0", "Cython >= 0.28", "numpy" ]
+build-backend = "setuptools.build_meta"

--- a/accelerate/setup.cfg
+++ b/accelerate/setup.cfg
@@ -1,0 +1,24 @@
+[metadata]
+name = PyOpenGL-accelerate
+version = attr: OpenGL_accelerate.__init__.__version__
+description = Acceleration code for PyOpenGL
+author = Mike C. Fletcher
+author_email = mcfletch@vrplumber.com
+url = http://pyopengl.sourceforge.net
+download_url = http://sourceforge.net/project/showfiles.php?group_id=5988
+license = BSD
+long_description = file: readme.txt
+long_description_content_type = text/plain
+keywords = PyOpenGL, accelerate, Cython
+platforms = Win32, Linux, OS-X, Posix
+classifiers =
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: C
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Multimedia :: Graphics :: 3D Rendering
+    Intended Audience :: Developers
+
+[options]
+packages = OpenGL_accelerate

--- a/accelerate/setup.py
+++ b/accelerate/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 """Builds accelleration functions for PyOpenGL
 """
-try:
-    from setuptools import setup,Extension
-except ImportError:
-    from distutils.core import setup,Extension
+
+from setuptools import setup, Extension
+
 try:
     from Cython.Distutils import build_ext
 except ImportError:
@@ -15,15 +14,6 @@ else:
 import sys, os
 
 HERE = os.path.normpath(os.path.abspath(os.path.dirname( __file__ )))
-with open(os.path.join(HERE, 'README.txt'), 'r') as f:
-    long_description = f.read()
-
-version = None
-# get version from __init__.py
-for line in open( os.path.join( HERE,'OpenGL_accelerate','__init__.py') ):
-    if line.startswith( '__version__' ):
-        version = eval(line.split( '=' )[1].strip())
-assert version, """Couldn't determine version string!"""
 
 extensions = [
 ]
@@ -41,7 +31,6 @@ def cython_extension( name, include_dirs = (), ):
             ),
         ],
         include_dirs = [
-            os.path.join(HERE,'..'),
             os.path.join(HERE,'src'),
             HERE,
         ]+ list(include_dirs),
@@ -92,7 +81,7 @@ else:
 
     ) )
 
-if __name__ == "__main__":
+if True:  # minimise Git diff
     # Workaround for Broken apple Python build params echoed in distutils
     # Approach taken from the PyMongo driver. OS-X Python builds were created with 
     # non-existent flag, and distutils passes those flags to the extension 
@@ -104,45 +93,19 @@ if __name__ == "__main__":
         for key in ('CFLAGS', 'PY_CFLAGS'):
             if key in res:
                 res[key] = res[key].replace('-mno-fused-madd', '')
-    
-    extraArguments = {
-        'classifiers': [
-            """License :: OSI Approved :: BSD License""",
-            """Programming Language :: Python""",
-            """Programming Language :: Python :: 3""",
-            """Programming Language :: C""",
-            """Topic :: Software Development :: Libraries :: Python Modules""",
-            """Topic :: Multimedia :: Graphics :: 3D Rendering""",
-            """Intended Audience :: Developers""",
-        ],
-        'keywords': 'PyOpenGL,accelerate,Cython',
-        'long_description' : long_description,
-        'long_description_content_type' : 'text/plain',
-        'platforms': ['Win32','Linux','OS-X','Posix'],
-    }
+
+    extraArguments = {}
     ### Now the actual set up call
     if have_cython:
         extraArguments['cmdclass'] = {
             'build_ext': build_ext,
         }
     setup (
-        name = "PyOpenGL-accelerate",
-        version = version,
-        description = "Acceleration code for PyOpenGL",
-        author = "Mike C. Fletcher",
-        author_email = "mcfletch@vrplumber.com",
-        url = "http://pyopengl.sourceforge.net",
-        download_url = "http://sourceforge.net/project/showfiles.php?group_id=5988",
-        license = 'BSD',
-        packages = ['OpenGL_accelerate'],
         options = {
             'sdist': {
                 'formats': ['gztar','zip'],
                 'force_manifest': True,
             },
-        },
-        package_dir = {
-            'OpenGL_accelerate':'OpenGL_accelerate',
         },
         ext_modules=extensions,
         **extraArguments

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,15 +85,16 @@ init:
 install:
   - "powershell appveyor\\install.ps1"
   - "%CMD_IN_ENV% %PYTHON%\\python.exe -m pip install --prefer-binary pygame pytest numpy"
-  - "%CMD_IN_ENV% %PYTHON%\\python.exe setup.py install"
+  - "%CMD_IN_ENV% %PYTHON%\\python.exe -m pip install ."
   - cd accelerate
-  - "%CMD_IN_ENV% %PYTHON%\\python.exe setup.py install"
+  - "%CMD_IN_ENV% %PYTHON%\\python.exe -m pip install ."
   - cd ..
 
 build_script:
   - cd accelerate
-  - "ECHO %WITH_COMPILER% %PYTHON%/python.exe setup.py bdist_wheel"
-  - "%WITH_COMPILER% %PYTHON%/python.exe setup.py bdist_wheel"
+  - "%PYTHON%\\python.exe -m pip install build"
+  - "ECHO %WITH_COMPILER% %PYTHON%/python.exe -m build ."
+  - "%WITH_COMPILER% %PYTHON%/python.exe -m build ."
   - cd ..
 
 test_script:

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -164,7 +164,8 @@ function InstallPip ($python_home) {
         Write-Host "Executing:" $python_path $GET_PIP_PATH
         & $python_path $GET_PIP_PATH
     } else {
-        Write-Host "pip already installed."
+        Write-Host "pip already installed. Upgrading..."
+        & $python_path -m pip install --upgrade pip
     }
 }
 
@@ -217,7 +218,8 @@ function InstallMinicondaPip ($python_home) {
         Write-Host $conda_path $args
         Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
     } else {
-        Write-Host "pip already installed."
+        Write-Host "pip already installed. Upgrading..."
+        & $conda_path update --yes pip
     }
 }
 
@@ -229,7 +231,7 @@ function InstallPackage ($python_home, $pkg) {
 function main () {
     InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
     InstallPip $env:PYTHON
-    InstallPackage $env:PYTHON wheel numpy pygame
+    InstallPackage $env:PYTHON wheel
 }
 
 main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = [ "setuptools >= 42.0" ]
+build-backend = "setuptools.build_meta"

--- a/readme.rst
+++ b/readme.rst
@@ -6,12 +6,12 @@ PyOpenGL is normally distributed via PyPI using standard pip::
     $ pip install PyOpenGL PyOpenGL_accelerate
 
 You can install this repository by branching/cloning and running
-setup.py::
+``pip``::
 
     $ cd pyopengl
-    $ python setup.py develop
+    $ pip install -e .
     $ cd accelerate
-    $ python setup.py develop
+    $ pip install -e .
 
 Note that to compile PyOpenGL_accelerate you will need to have 
 a functioning Python extension-compiling environment.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[metadata]
+name = PyOpenGL
+version = attr: OpenGL.version.__version__
+description = Standard OpenGL bindings for Python
+author = Mike C. Fletcher
+author_email = mcfletch@vrplumber.com
+url = http://pyopengl.sourceforge.net
+download_url = http://sourceforge.net/projects/pyopengl/files/PyOpenGL/
+license = BSD
+long_description = file: readme.rst
+long_description_content_type = text/x-rst
+keywords = Graphics, 3D, OpenGL, GLU, GLUT, GLE, GLX, EXT, ARB, Mesa, ctypes
+classifiers =
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Topic :: Multimedia :: Graphics :: 3D Rendering
+    Topic :: Software Development :: Libraries :: Python Modules
+    Intended Audience :: Developers
+
+[options]
+packages = find:
+
+[options.packages.find]
+include = OpenGL*

--- a/setup.py
+++ b/setup.py
@@ -3,51 +3,8 @@
 """
 import sys, os
 extra_commands = {}
-try:
-    from setuptools import setup 
-except ImportError:
-    from distutils.core import setup
 
-HERE = os.path.normpath(os.path.abspath(os.path.dirname( __file__ )))
-with open(os.path.join(HERE, 'readme.rst'), 'r') as f:
-    long_description = f.read()
-
-sys.path.insert(0, '.' )
-metadata = dict(
-    version = [
-        (line.split('=')[1]).strip().strip('"').strip("'")
-        for line in open(os.path.join('OpenGL','version.py'))
-        if line.startswith( '__version__' )
-    ][0],
-    author = 'Mike C. Fletcher',
-    author_email = 'mcfletch@vrplumber.com',
-    url = 'http://pyopengl.sourceforge.net',
-    license = 'BSD',
-    download_url = "http://sourceforge.net/projects/pyopengl/files/PyOpenGL/",
-    keywords = 'Graphics,3D,OpenGL,GLU,GLUT,GLE,GLX,EXT,ARB,Mesa,ctypes',
-    classifiers = [
-        """License :: OSI Approved :: BSD License""",
-        """Programming Language :: Python""",
-        """Programming Language :: Python :: 3""",
-        """Topic :: Multimedia :: Graphics :: 3D Rendering""",
-        """Topic :: Software Development :: Libraries :: Python Modules""",
-        """Intended Audience :: Developers""",
-    ],
-    long_description = long_description,
-    long_description_content_type = 'text/x-rst',
-)
-
-def is_package( path ):
-    return os.path.isfile( os.path.join( path, '__init__.py' ))
-def find_packages( root ):
-    """Find all packages under this directory"""
-    for path, directories, files in os.walk( root ):
-        if is_package( path ):
-            yield path.replace( '/','.' )
-
-requirements = []
-if sys.hexversion < 0x2050000:
-    requirements.append( 'ctypes' )
+from setuptools import setup
 
 from distutils.command.install_data import install_data
 class smart_install_data(install_data):
@@ -77,9 +34,6 @@ else:
 
 if __name__ == "__main__":
     setup(
-        name = "PyOpenGL",
-        packages = list( find_packages('OpenGL') ),
-        description = 'Standard OpenGL bindings for Python',
         options = {
             'sdist': {
                 'formats': ['gztar'],
@@ -88,5 +42,4 @@ if __name__ == "__main__":
         },
         data_files = datafiles,
         cmdclass = extra_commands,
-        **metadata
     )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -139,14 +139,13 @@ def ensure_virtualenv( python, numpy=True ):
     
     subprocess.check_call([
         os.path.join( bin_path, 'python' ),
-        'setup.py',
-        'build_ext', '--force',
-        'install',
+        '-m', 'pip', 'install',
+        '.',
     ], cwd = os.path.join( HERE, '..','OpenGL_accelerate' ))
     subprocess.check_call([
         os.path.join( bin_path, 'python' ),
-        'setup.py',
-        'develop',
+        '-m', 'pip', 'install',
+        '-e', '.',
     ], cwd = os.path.join( HERE, '..' ))
 
 def env_setup():


### PR DESCRIPTION
This differs from #84 by not specifying project configuration in pyproject.toml. This means older Python version support is not dropped.

* Specify build backend in pyproject.toml (PEP 518)
* Remove unused 'ctypes' dependency
* Remove empty accelerate requirements file
* Remove '..' from accelerate build include-dirs
* Install package with pip in AppVeyor
* Build package with PyPA's Build in AppVeyor
* Skip explicit build dependency install in AppVeyor
* Upgrade pip if found in AppVeyor