### PR TITLE
pin Cython to < 3.0

### DIFF
--- a/accelerate/dev-requirements.txt
+++ b/accelerate/dev-requirements.txt
@@ -1,3 +1,3 @@
 tox
-cython>=0.28
+cython>=0.28,<3.0
 numpy


### PR DESCRIPTION
Cython 3.0 is still in beta, but it has quite a few changes, so this should be pinned to less than 3.0 until it can be tested there,

And then it should probably be pinned to >= 3.0