### PR TITLE
Implement getGLUTFontPointer for EGL platform

### DIFF
--- a/OpenGL/platform/egl.py
+++ b/OpenGL/platform/egl.py
@@ -104,3 +104,19 @@ class EGLPlatform( baseplatform.BasePlatform ):
     @baseplatform.lazy_property
     def GetCurrentContext( self ):
         return self.EGL.eglGetCurrentContext
+
+    def getGLUTFontPointer( self, constant ):
+        """Platform specific function to retrieve a GLUT font pointer
+
+        GLUTAPI void *glutBitmap9By15;
+        #define GLUT_BITMAP_9_BY_15		(&glutBitmap9By15)
+
+        Key here is that we want the addressof the pointer in the DLL,
+        not the pointer in the DLL.  That is, our pointer is to the
+        pointer defined in the DLL, we don't want the *value* stored in
+        that pointer.
+        """
+        name = [ x.title() for x in constant.split( '_' )[1:] ]
+        internal = 'glut' + "".join( [x.title() for x in name] )
+        pointer = ctypes.c_void_p.in_dll( self.GLUT, internal )
+        return ctypes.c_void_p(ctypes.addressof(pointer))


### PR DESCRIPTION
This is simply copied from GLX, but there doesn't seem like there should be any differences.

Fixes #89.