### PR TITLE
also check for .so without version extension

### DIFF
--- a/OpenGL/platform/ctypesloader.py
+++ b/OpenGL/platform/ctypesloader.py
@@ -52,7 +52,7 @@ def _loadLibraryPosix(dllType, name, mode):
     suffix = '.so'
     base_name = prefix + name + suffix
     
-    filenames_to_try = []
+    filenames_to_try = [base_name]
     # If a .so is missing, let's try libs with so version (e.g libGLU.so.9, libGLU.so.8 and so on)
     filenames_to_try.extend(list(reversed([
         base_name + '.%i' % i for i in range(0, 10)


### PR DESCRIPTION
Debian bookworm and later do not ship the freeglut3 library any more that provided the versioned symlink libglut.so.3 for the libglut.so.3.12.0 library, but there is libglut.so , still, and libglut.so.3.12.

$ ls -l /usr/lib/x86_64-linux-gnu/*glut*
-rw-r--r-- 1 root root 654216  5. Nov 21:59 /usr/lib/x86_64-linux-gnu/libglut.a
lrwxrwxrwx 1 root root     15  5. Nov 21:59 /usr/lib/x86_64-linux-gnu/libglut.so -> libglut.so.3.12
lrwxrwxrwx 1 root root     17  5. Nov 21:59 /usr/lib/x86_64-linux-gnu/libglut.so.3.12 -> libglut.so.3.12.0
-rw-r--r-- 1 root root 356016  5. Nov 21:59 /usr/lib/x86_64-linux-gnu/libglut.so.3.12.0

Several LinuxCNC issues/PRs are affected by this little omission, see https://github.com/LinuxCNC/linuxcnc/pull/2259 and https://github.com/LinuxCNC/linuxcnc/issues/1599. I tested this change locally and it worked for me. To test this run, 
```
#!/usr/bin/python3
from OpenGL.GL import *
from OpenGL.GLUT import *
from OpenGL.GLU import *
glutInit()
```
on Debian bookworm or later. Please also see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1029936 and likely also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=512225.
