### PR TITLE
Fix ctypes FormatHandler for Python 3.12+

### DIFF
--- a/OpenGL/__init__.py
+++ b/OpenGL/__init__.py
@@ -308,7 +308,7 @@ FormatHandler(
     "ctypesparameter",
     "OpenGL.arrays.ctypesparameters.CtypesParameterHandler",
     [
-        _bi + ".CArgObject",
+        ("_ctypes" if sys.version_info[:2] >= (3,12) else _bi) + ".CArgObject",
         "ctypes.c_uint",
         "ctypes.c_int",
         "ctypes.c_float",


### PR DESCRIPTION
In Python 3.12, CArgObject moved from builtins to _ctypes it seems.

Fixes #99.