### PR TITLE
fix resource warning

### DIFF
--- a/OpenGL/platform/egl.py
+++ b/OpenGL/platform/egl.py
@@ -73,7 +73,8 @@ class EGLPlatform( baseplatform.BasePlatform ):
         #   https://github.com/raspberrypi/firmware/issues/110
         import os
         if os.path.exists('/proc/cpuinfo'):
-            info = open('/proc/cpuinfo').read()
+            with open('/proc/cpuinfo', 'r') as f:
+                info = f.read()
             if 'BCM2708' in info or 'BCM2709' in info:
                 assert self.GLES2
         try:


### PR DESCRIPTION
```
/usr/lib/python3.11/site-packages/OpenGL/platform/egl.py:76: ResourceWarning: unclosed file <_io.TextIOWrapper 
name='/proc/cpuinfo' mode='r' encoding='UTF-8'>
  info = open('/proc/cpuinfo').read()
```