### PR TITLE
PYPY3 Add support for pypy3 in FormatHandler

### DIFF
--- a/OpenGL/__init__.py
+++ b/OpenGL/__init__.py
@@ -301,6 +301,7 @@ FormatHandler(
         "_ctypes.PyCArrayType",
         "_ctypes.Array",
         "_ctypes.array.Array",
+        "_ctypes.array.ArrayMeta",
     ],
     isOutput=True,
 )


### PR DESCRIPTION
Add `_ctypes.array.ArrayMeta` to classes recognized by `ctypesarrays` formathandler.  This is the class used by arrays on PyPy3.10.  Adding this makes the test suite pass on PyPy3.10 7.3.13.

Fixes #108