### PR TITLE
accelerate: Fix C type errors for GCC 14/Clang compatibility

### DIFF
--- a/accelerate/src/numpy_formathandler.pyx
+++ b/accelerate/src/numpy_formathandler.pyx
@@ -21,7 +21,7 @@ cdef extern from "numpy/arrayobject.h":
     int PyArray_ISCARRAY_RO( np.ndarray instance )
     cdef np.ndarray PyArray_Zeros(int nd, np.Py_intptr_t* dims, np.dtype, int fortran)
     cdef np.ndarray PyArray_EnsureArray(object)
-    cdef int PyArray_FillWithScalar(object, object)
+    cdef int PyArray_FillWithScalar(np.ndarray, object)
     cdef void import_array()
     cdef void* PyArray_DATA( np.ndarray )
     cdef int PyArray_NDIM( np.ndarray )

--- a/accelerate/src/numpy_formathandler.pyx
+++ b/accelerate/src/numpy_formathandler.pyx
@@ -22,7 +22,6 @@ cdef extern from "numpy/arrayobject.h":
     cdef np.ndarray PyArray_Zeros(int nd, np.Py_intptr_t* dims, np.dtype, int fortran)
     cdef np.ndarray PyArray_EnsureArray(object)
     cdef int PyArray_FillWithScalar(np.ndarray, object)
-    cdef void import_array()
     cdef void* PyArray_DATA( np.ndarray )
     cdef int PyArray_NDIM( np.ndarray )
     cdef int *PyArray_DIMS( np.ndarray )
@@ -226,4 +225,4 @@ cdef class NumpyHandler(FormatHandler):
 
 # Cython numpy tutorial neglects to mention this AFAICS
 # get segfaults without it
-import_array()
+np.import_array()


### PR DESCRIPTION
This fixes type errors that cause build failures with current compilers:

```
src/numpy_formathandler.c: In function ‘__pyx_f_17OpenGL_accelerate_19numpy_form
athandler_12NumpyHandler_c_asArray’:
src/numpy_formathandler.c:6412:43: error: passing argument 1 of ‘(int (*)(PyArrayObject *, PyObject *))*(PyArray_API + 832)’ from incompatible pointer type
 6412 |     __pyx_v_res = PyArray_FillWithScalar(((PyObject *)__pyx_v_working), __pyx_v_instance);
      |                                          ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                           |
      |                                           PyObject * {aka struct _object *}
src/numpy_formathandler.c:6412:43: note: expected ‘PyArrayObject *’ {aka ‘struct tagPyArrayObject_fields *’} but argument is of type ‘PyObject *’ {aka ‘struct _object *’}
src/numpy_formathandler.c: In function ‘__pyx_pymod_exec_numpy_formathandler’:
src/numpy_formathandler.c:9799:3: error: returning ‘void *’ from a function with return type ‘int’ makes integer from pointer without a cast
 9799 |   import_array();
      |   ^~~~~~~~~~~~
```

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
