### PR TITLE
Updated GitHub actions versions

### DIFF
--- a/.github/workflows/accelerate-manylinux.yml
+++ b/.github/workflows/accelerate-manylinux.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build source tarballs and root wheels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install build
@@ -38,13 +38,13 @@ jobs:
           accelerate
 
       - name: Save Core Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: core
           path: dist/*
 
       - name: Save Accelerate Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: accel
           path: accelerate/dist/*
@@ -60,19 +60,19 @@ jobs:
           - macOS-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Build wheels (develop)
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.22.0
         if: ${{ github.ref == 'refs/heads/develop' }}
         with:
           package-dir: "./accelerate"
@@ -82,7 +82,7 @@ jobs:
           CIBW_SKIP: "pp*"
 
       - name: Build wheels (master)
-        uses: pypa/cibuildwheel@v2.12.3
+        uses: pypa/cibuildwheel@v2.22.0
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           package-dir: "./accelerate"
@@ -92,9 +92,9 @@ jobs:
           CIBW_SKIP: "pp*"
 
       - name: Save wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: accel-binary
+          name: accel-binary-${{ matrix.os }}
           path: accelerate/dist/*.whl
 
   pypi-publish-accel:
@@ -109,16 +109,17 @@ jobs:
       id-token: write
     steps:
       - name: Download Accelerate
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download-accelerate
         with:
           name: accel
           path: dist
       - name: Download Accelerate Binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download-accelerate-bin
         with:
-          name: accel-binary
+          pattern: accel-binary-*
+          merge-multiple: true
           path: dist
 
       # retrieve your distributions here
@@ -142,7 +143,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Core
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: core


### PR DESCRIPTION
## New GitHub actions versions
+ `actions/checkout` updated from v3 to v4 (see [actions/checkout](https://github.com/actions/checkout/releases))
+ `actions/setup-python` updated from v4 to v5 (see [actions/setup-python](https://github.com/actions/setup-python/releases))
+ `actions/upload-artifact` updated from v3 to v4 (see [actions/upload-artifact](https://github.com/actions/upload-artifact/releases))
+ `actions/download-artifact` updated from v3 to v4 (see [actions/download-artifact](https://github.com/actions/download-artifact/releases))

## Required changes
In `upload-artifact@v4` artifacts are immutable. Therefore uploading artifacts with the same name is no longer permitted. I adjusted the workflow according to [MIGRATION.md](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md). 