### PR TITLE
ARM Runners

### DIFF
--- a/.github/workflows/accelerate-manylinux.yml
+++ b/.github/workflows/accelerate-manylinux.yml
@@ -50,14 +50,21 @@ jobs:
           path: accelerate/dist/*
 
   wheels:
-    name: Build architecture-specific wheels on ${{ matrix.os }}
+    name: Build architecture-specific wheels on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macOS-latest
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-latest]  # Use specific versions for clarity
+        arch: [x86_64, arm64]
+        exclude:
+          - os: ubuntu-latest
+            arch: arm64
+          - os: ubuntu-24.04-arm  # No need to specify arch, it's already implicit
+            arch: x86_64  # Exclude x86_64 on ARM
+          - os: macos-latest   # Exclude macOS 14-15 (Sonoma)
+            arch: x86_64   # Exclude x86_64 explicitly
+          - os: macos-13  # Exclude macOS 13 (Ventura) - arm64
+            arch: arm64   # Exclude arm64 on macOS 13
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -65,11 +72,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
 
       - name: Build wheels (develop)
         uses: pypa/cibuildwheel@v2.22.0
@@ -79,7 +81,8 @@ jobs:
           output-dir: "./accelerate/dist"
         env:
           BUILD_EXTENSION: yes
-          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_MACOS: ${{ matrix.os }}-${{ matrix.arch }}
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
 
       - name: Build wheels (master)
         uses: pypa/cibuildwheel@v2.22.0
@@ -89,12 +92,13 @@ jobs:
           output-dir: "./accelerate/dist"
         env:
           BUILD_EXTENSION: yes
-          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
 
       - name: Save wheels
         uses: actions/upload-artifact@v4
         with:
-          name: accel-binary-${{ matrix.os }}
+          name: accel-binary-${{ matrix.os }}-${{ matrix.arch }}
           path: accelerate/dist/*.whl
 
   pypi-publish-accel:

--- a/build-manylinux.sh
+++ b/build-manylinux.sh
@@ -1,10 +1,19 @@
-#! /bin/bash
+#!/bin/bash
+
+ARCH=$(uname -m)
+if [ "$ARCH" == "x86_64" ]; then
+  MANYLINUX="manylinux_2_28_x86_64"
+elif [ "$ARCH" == "aarch64" ]; then
+  MANYLINUX="manylinux_2_28_aarch64"
+else
+  echo "Unsupported architecture: $ARCH"
+  exit 1
+fi
 
 docker run \
     -it \
-    -v`pwd`:/io \
-    -ephemeral \
-    -ePLAT=manylinux2014_x86_64 \
+    -v "$(pwd)":/io \
+    -e PLAT="$MANYLINUX" \
     --rm \
-    quay.io/pypa/manylinux2014_x86_64 \
+    quay.io/pypa/"$MANYLINUX" \
     /io/accelerate/_build-manylinux.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,19 @@ ignore = [
 
 [tool.ruff.format]
 quote-style = "single"
+
+[tool.cibuildwheel]
+archs = "native"
+# Necessary to see build output from the actual compilation
+build-verbosity = 1
+
+# linux images
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"
+
+# Don't test Python 3.8 wheels on macOS/arm64
+test-skip="cp38-macosx_*:arm64"
+
+# Needed for full C++17 support
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.15"


### PR DESCRIPTION
This pull request includes several updates to the build and testing configuration to better support multiple architectures and improve clarity. The changes primarily affect the CI workflow, build scripts, and configuration files.

### CI Workflow Updates:

* [`.github/workflows/accelerate-manylinux.yml`](diffhunk://#diff-eacc8610bc8952113ebf76dd7a87fe92f4161be6e66498664e72ce8d629f0c1cL53-L72): Updated the job matrix to include specific OS versions and architectures, and excluded certain combinations to avoid unnecessary builds. Also updated the naming convention for artifacts to include architecture information. [[1]](diffhunk://#diff-eacc8610bc8952113ebf76dd7a87fe92f4161be6e66498664e72ce8d629f0c1cL53-L72) [[2]](diffhunk://#diff-eacc8610bc8952113ebf76dd7a87fe92f4161be6e66498664e72ce8d629f0c1cL82-R83) [[3]](diffhunk://#diff-eacc8610bc8952113ebf76dd7a87fe92f4161be6e66498664e72ce8d629f0c1cL92-R99)

* manylinux_2014 will move to 2_28. Deprecation this year 2025.

* Windows arm runners are coming q2 2025.

### Build Script Updates:

* [`build-manylinux.sh`](diffhunk://#diff-60b11f7de3eb86154f619916e0311c9981594d9c4a286abedfe1eaa65f05a95eR3-R18): Modified the script to dynamically set the `MANYLINUX` environment variable based on the detected architecture, ensuring compatibility with both x86_64 and aarch64 architectures.

### Configuration Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R99-R118): Added `cibuildwheel` configuration to specify architectures, verbosity, test commands, and necessary environment variables for macOS builds. This ensures proper build and test setups for different architectures.