### PR TITLE
Fix import error on aarch64: define 'long' using ctypes.c_long

### DIFF
--- a/accelerate/src/vbo.pyx
+++ b/accelerate/src/vbo.pyx
@@ -1,6 +1,7 @@
 """Cython-coded VBO implementation"""
 #cython: language_level=3
 import ctypes, weakref
+from ctypes import c_long as long
 from OpenGL_accelerate.formathandler cimport FormatHandler
 from OpenGL import error
 from OpenGL._bytes import bytes,unicode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Source = "https://github.com/mcfletch/pyopengl"
 Documentation = "https://mcfletch.github.io/pyopengl/documentation/index.html"
 
 [build-system]
-requires = [ "setuptools >= 42.0" ]
+requires = [ "setuptools >= 42.0", "cython>=3.0.0" ]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary

On Linux ARM64 (aarch64) platforms, installing PyOpenGL_accelerate fails with the following error:

```
Error compiling Cython file:
...
    self.buffer = long( buffers )
                          ^
src/vbo.pyx:191:26: undeclared name not builtin: long
```
This happens because the built-in long type is not defined in Python 3 on ARM64 platforms, unlike some legacy Python 2 or x86-based assumptions. This breaks Cython compilation when trying to cast buffer identifiers.

This patch imports `long` from `ctypes.c_long`, which resolves the issue on these platforms.

## Changes

- Added `from ctypes import c_long as long` to handle missing `long` type on aarch64.

## Platform tested

- Linux on ARM64 (Ubuntu 22.04, aarch64)