### PR TITLE
add tobytes to support numpy>=2.3.0

### DIFF
--- a/OpenGL/GL/ARB/shader_objects.py
+++ b/OpenGL/GL/ARB/shader_objects.py
@@ -248,8 +248,8 @@ def glGetActiveUniformARB(baseOperation,program, index,bufSize=None):
         bufSize = int(glGetObjectParameterivARB( program, GL_OBJECT_ACTIVE_UNIFORM_MAX_LENGTH_ARB))
     if index < max_index and index >= 0:
         length,name,size,type = baseOperation( program, index, bufSize )
-        if hasattr(name,'tostring'):
-            name = name.tostring().rstrip(b'\000')
+        if hasattr(name,'tobytes'):
+            name = name.tobytes().rstrip(b'\000')
         elif hasattr(name,'value'):
             name = name.value
         return name,size,type

--- a/OpenGL/GL/ARB/vertex_shader.py
+++ b/OpenGL/GL/ARB/vertex_shader.py
@@ -135,8 +135,8 @@ def glGetActiveAttribARB(baseOperation, program, index):
     length = int(glGetObjectParameterivARB( program, GL_OBJECT_ACTIVE_ATTRIBUTE_MAX_LENGTH_ARB))
     if index < max_index and index >= 0 and length > 0:
         length,name,size,type = baseOperation( program, index )
-        if hasattr(name,'tostring'):
-            name = name.tostring().rstrip(b'\000')
+        if hasattr(name,'tobytes'):
+            name = name.tobytes().rstrip(b'\000')
         elif hasattr(name,'value'):
             name = name.value
         return name,size,type

--- a/OpenGL/GL/VERSION/GL_2_0.py
+++ b/OpenGL/GL/VERSION/GL_2_0.py
@@ -379,8 +379,8 @@ def glGetActiveAttrib(baseOperation, program, index, bufSize=None,*args):
     if bufSize <= 0:
         raise RuntimeError( 'Active attribute length reported', bufsize )
     name,size,type = baseOperation( program, index, bufSize, *args )[1:]
-    if hasattr(name,'tostring'):
-        name = name.tostring().rstrip(b'\000')
+    if hasattr(name,'tobytes'):
+        name = name.tobytes().rstrip(b'\000')    
     elif hasattr(name,'value'):
         name = name.value
     return name,size,type
@@ -408,8 +408,8 @@ def glGetActiveUniform(baseOperation,program, index,bufSize=None,*args):
         bufSize = int(glGetProgramiv( program, GL_ACTIVE_UNIFORM_MAX_LENGTH))
     if index < max_index and index >= 0:
         length,name,size,type = baseOperation( program, index, bufSize, *args )
-        if hasattr(name,'tostring'):
-            name = name.tostring().rstrip(b'\000')
+        if hasattr(name,'tobytes'):
+            name = name.tobytes().rstrip(b'\000')
         elif hasattr(name,'value'):
             name = name.value
         return name,size,type

--- a/OpenGL/GLES2/VERSION/GLES2_2_0.py
+++ b/OpenGL/GLES2/VERSION/GLES2_2_0.py
@@ -353,8 +353,8 @@ def glGetActiveUniform(baseOperation,program, index,bufSize=None,*args):
         bufSize = int(glGetProgramiv( program, GL_ACTIVE_UNIFORM_MAX_LENGTH))
     if index < max_index and index >= 0:
         length,name,size,type = baseOperation( program, index, bufSize, *args )
-        if hasattr(name,'tostring'):
-            name = name.tostring().rstrip(b'\000')
+        if hasattr(name,'tobytes'):
+            name = name.tobytes().rstrip(b'\000')
         elif hasattr(name,'value'):
             name = name.value
         return name,size,type
@@ -383,8 +383,8 @@ def glGetActiveAttrib(baseOperation, program, index, bufSize=None,*args):
     if bufSize <= 0:
         raise RuntimeError( 'Active attribute length reported', bufsize )
     name,size,type = baseOperation( program, index, bufSize, *args )[1:]
-    if hasattr(name,'tostring'):
-        name = name.tostring().rstrip(b'\000')
+    if hasattr(name,'tobytes'):
+        name = name.tobytes().rstrip(b'\000')    
     elif hasattr(name,'value'):
         name = name.value
     return name,size,type

--- a/OpenGL/arrays/strings.py
+++ b/OpenGL/arrays/strings.py
@@ -56,8 +56,8 @@ class StringHandler(formathandler.FormatHandler):
         """Convert given value to an array value of given typeCode"""
         if isinstance(value, bytes):
             return value
-        elif hasattr(value, 'tostring'):
-            return value.tostring()
+        elif hasattr(value, 'tobytes'):
+            return value.tobytes()
         elif hasattr(value, 'raw'):
             return value.raw
         # could convert types to string here, but we're not registered for


### PR DESCRIPTION
Close #149 

Went through and added a `tobytes` option wherever `tostring` was being used to support numpy >= 2.3.0, which removed the deprecated `tostring` method for arrays. 

Let me know if this needs any additional tests. 