### PR TITLE
WIP: Add gitHub workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: test
+
+on: [push, pull_request]
+# on:
+  # push:
+  #   branches: [ "master" ]
+  # pull_request:
+  #   branches: [ "master" ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+# tox could handle the python matrix -- but this way we get better reporting from gitHub actions
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install pyopengl
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+
+    - name: Install test dependencies
+      run: |
+        python -m pip install numpy psutil pygame pytest
+
+    - name: Test pyopengl
+      run: |
+        pytest tests
+
+    # - name: Test with tox
+    #   run: |
+    #     tox
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   - pull_request
 
 jobs:
-  build:
+  test_opengl:
     strategy:
       fail-fast: false
       matrix:
@@ -18,6 +18,7 @@ jobs:
         os:
 # Ubuntu test runners don't have OpenGL
 #   I *think* Mesa could be installed, but haven't figured that out yet.
+# maybe as simple as: https://github.com/marketplace/actions/setup-opengl
 #           - ubuntu-latest
           - windows-latest
           - macos-latest
@@ -43,4 +44,41 @@ jobs:
       run: |
         pytest tests
 
+  test_opengl-accelerate:
+    strategy:
+      fail-fast: false
+      matrix:
+# tox could handle the python matrix -- but this way we get better
+#   separation and reporting from gitHub actions
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os:
+# Ubuntu test runners don't have OpenGL
+#   I *think* Mesa could be installed, but haven't figured that out yet.
+#           - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Accelerate
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .  # also need PyOpenGL
+        python -m pip install accelerate/
+
+    - name: Install test dependencies
+      run: |
+        cd accelerate
+        python -m pip install -r test-requirements.txt
+
+    - name: Test Accelerate
+      run: |
+        cd accelerate
+        pytest tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,6 @@ jobs:
     - name: Install Accelerate
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .  # also need PyOpenGL
         python -m pip install accelerate/
 
     - name: Install test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,21 +3,24 @@
 
 name: test
 
-on: [push, pull_request]
-# on:
-  # push:
-  #   branches: [ "master" ]
-  # pull_request:
-  #   branches: [ "master" ]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-# tox could handle the python matrix -- but this way we get better reporting from gitHub actions
+# tox could handle the python matrix -- but this way we get better
+#   separation and reporting from gitHub actions
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os:
+# Ubuntu test runners don't have OpenGL
+#   I *think* Mesa could be installed, but haven't figured that out yet.
+#           - ubuntu-latest
+          - windows-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -40,7 +43,4 @@ jobs:
       run: |
         pytest tests
 
-    # - name: Test with tox
-    #   run: |
-    #     tox
 

--- a/accelerate/src/vbo.pyx
+++ b/accelerate/src/vbo.pyx
@@ -1,7 +1,6 @@
 """Cython-coded VBO implementation"""
 #cython: language_level=3
 import ctypes, weakref
-from ctypes import c_long as long
 from OpenGL_accelerate.formathandler cimport FormatHandler
 from OpenGL import error
 from OpenGL._bytes import bytes,unicode
@@ -189,8 +188,8 @@ cdef class VBO:
         assert not self.created, """Already created the buffer"""
         buffers = self.get_implementation().glGenBuffers(1)
         try:
-            self.buffer = long( buffers )
-        except (TypeError,ValueError) as err:
+            self.buffer = int( buffers )
+        except (TypeError, ValueError) as err:
             self.buffer = buffers[0]
         self.target = self.c_resolve( self.target_spec )
         self.usage = self.c_resolve( self.usage_spec )
@@ -243,7 +242,7 @@ cdef class VBO:
         """Add an integer to this VBO (offset)"""
         if hasattr( other, 'offset' ):
             other = other.offset
-        assert isinstance( other, (int,long) ), """Only know how to add integer/long offsets"""
+        assert isinstance( other, int), """Only know how to add integer offsets"""
         return VBOOffset( self, other )
     cdef int check_live( self ):
         if self.data is _NULL:

--- a/accelerate/src/vbo.pyx
+++ b/accelerate/src/vbo.pyx
@@ -1,6 +1,7 @@
 """Cython-coded VBO implementation"""
 #cython: language_level=3
 import ctypes, weakref
+from ctypes import c_long as long
 from OpenGL_accelerate.formathandler cimport FormatHandler
 from OpenGL import error
 from OpenGL._bytes import bytes,unicode


### PR DESCRIPTION
This is just a start:

It's running the tests in the multiple platforms, but most aren't passing:

1) Not doing Ubuntu -- the test runners don't have GL -- though Mesa could be added, I just haven't tried that yet.

2) A bunch of the PyOpenGL tests are failing. I haven't debugged that yet, as a bunch of tests are failing locally for me (on OS-X 14 Intel) so if I can't get them to pass locally -- what hope do I have on the CI ? 

3) We'll probably need to run only a subset of the tests anyway -- I think there's some interaction with the display that's going to be problematic regardless.

4) I added the patch from #146 -- to get Accelerate to compile

5) The accelerate tests are passing -- at least on Windows, OS-X tests aren't running at all right now ....

It would be nice to get this going though -- automated tests are a great thing! 


