### PR TITLE
Skip check_egl_platform_ext in case of PermissionError

### DIFF
--- a/tests/check_egl_platform_ext.py
+++ b/tests/check_egl_platform_ext.py
@@ -18,23 +18,27 @@ def main():
         raise RuntimeError("Need a /dev/dri/renderD* device to do rendering")
     if len(cards) > 1:
         print("Note, using first card: %s" % (cards[0]))
-    with open(cards[0], "w") as f:
-        gbm = ctypes.CDLL("libgbm.so.1")  # On Ubuntu, package libgbm1
-        dev = gbm.gbm_create_device(f.fileno())
-        dpy = platform_base.eglGetPlatformDisplayEXT(
-            platform_gbm.EGL_PLATFORM_GBM_MESA, ctypes.c_void_p(dev), ctypes.c_void_p(0)
-        )
-        print(dpy)
-        if EGL_1_5.eglGetPlatformDisplay:
-            dpy = EGL_1_5.eglGetPlatformDisplay(
-                platform_gbm.EGL_PLATFORM_GBM_MESA,
-                ctypes.c_void_p(dev),
-                ctypes.c_void_p(0),
+    try:
+        with open(cards[0], "w") as f:
+            gbm = ctypes.CDLL("libgbm.so.1")  # On Ubuntu, package libgbm1
+            dev = gbm.gbm_create_device(f.fileno())
+            dpy = platform_base.eglGetPlatformDisplayEXT(
+                platform_gbm.EGL_PLATFORM_GBM_MESA, ctypes.c_void_p(dev), ctypes.c_void_p(0)
             )
             print(dpy)
-        else:
-            print("No EGL_1_5 implementation")
-        print('OK')
+            if EGL_1_5.eglGetPlatformDisplay:
+                dpy = EGL_1_5.eglGetPlatformDisplay(
+                    platform_gbm.EGL_PLATFORM_GBM_MESA,
+                    ctypes.c_void_p(dev),
+                    ctypes.c_void_p(0),
+                )
+                print(dpy)
+            else:
+                print("No EGL_1_5 implementation")
+    except PermissionError as error:
+        print('SKIP')
+        raise RuntimeError(str(error)) from error
+    print('OK')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
pyopengl 3.1.9+dfsg-1.1 autopkgtest fails on arm64:

```
=================================== FAILURES ===================================
_________________________ test_check_egl_platform_ext __________________________

    @wraps(func)
    def test_x():
        log.info("Starting test: %s", filename)
        pipe = subprocess.Popen(
            [
                sys.executable,
                file,
            ],
            stdout=subprocess.PIPE,
            stderr=subprocess.PIPE,
        )
        try:
            stdout, stderr = pipe.communicate()
        except subprocess.TimeoutExpired:
            log.warning("TIMEOUT on %s", filename)
            pipe.kill()
            raise
        except subprocess.CalledProcessError as err:
            log.warning("ERROR reported by process: %s", err)
            raise
        output = stdout.decode('utf-8', errors='ignore')
        lines = [x.strip() for x in output.strip().splitlines()]
        if not lines:
            log.error(
                "Test did not produce output: %s",
                stderr.decode('utf-8', errors='ignore'),
            )
>           raise RuntimeError('Test script failure')
E           RuntimeError: Test script failure

tests/test_checks.py:77: RuntimeError
------------------------------ Captured log call -------------------------------
ERROR    test_checks:test_checks.py:73 Test did not produce output: Traceback (most recent call last):
  File "/tmp/autopkgtest.dCNMA4/autopkgtest_tmp/tests/check_egl_platform_ext.py", line 41, in <module>
    main()
    ~~~~^^
  File "/tmp/autopkgtest.dCNMA4/autopkgtest_tmp/tests/check_egl_platform_ext.py", line 21, in main
    with open(cards[0], "w") as f:
         ~~~~^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/dev/dri/renderD128'
```

Skip this test in case of a permission error on the DRI device.

Bug-Ubuntu: https://launchpad.net/bugs/2115791