### PR TITLE
Fix FTBFS with Cython 3.1.x

### DIFF
--- a/accelerate/src/vbo.pyx
+++ b/accelerate/src/vbo.pyx
@@ -188,7 +188,7 @@ cdef class VBO:
         assert not self.created, """Already created the buffer"""
         buffers = self.get_implementation().glGenBuffers(1)
         try:
-            self.buffer = long( buffers )
+            self.buffer = int( buffers )
         except (TypeError,ValueError) as err:
             self.buffer = buffers[0]
         self.target = self.c_resolve( self.target_spec )
@@ -242,7 +242,7 @@ cdef class VBO:
         """Add an integer to this VBO (offset)"""
         if hasattr( other, 'offset' ):
             other = other.offset
-        assert isinstance( other, (int,long) ), """Only know how to add integer/long offsets"""
+        assert isinstance( other, int ), """Only know how to add integer offsets"""
         return VBOOffset( self, other )
     cdef int check_live( self ):
         if self.data is _NULL:


### PR DESCRIPTION
Cython 3.1.0 has removed support for Python 2, which includes the 'long' data type.  Simply switch to 'int' which should be the same thing in Python 3.