### PR TITLE
Use EGLPlatform plugin on android

### DIFF
--- a/OpenGL/__init__.py
+++ b/OpenGL/__init__.py
@@ -223,6 +223,7 @@ PlatformPlugin("posix", "OpenGL.platform.glx.GLXPlatform")
 PlatformPlugin("x11", "OpenGL.platform.glx.GLXPlatform")  # xdg session type
 PlatformPlugin("osmesa", "OpenGL.platform.osmesa.OSMesaPlatform")
 PlatformPlugin("egl", "OpenGL.platform.egl.EGLPlatform")
+PlatformPlugin("android", "OpenGL.platform.egl.EGLPlatform")
 PlatformPlugin("wayland", "OpenGL.platform.egl.EGLPlatform")  # xdg session type
 PlatformPlugin(
     "xwayland", "OpenGL.platform.egl.EGLPlatform"


### PR DESCRIPTION
Beginning in python 3.13, cpython officially supports android. Without this patch, attempting to use `OpenGL.EGL` on android fails with GLX errors, because there is no GLX on android. Using this one-line patch corrects the problem. On recent versions of cpython `sys.platform == "android"`. Tested with python 3.14 on android Quest 3 HMD.
