### PR TITLE
Fix calls to glXGetCurrentContext in GLX/X11 environments

### DIFF
--- a/OpenGL/platform/glx.py
+++ b/OpenGL/platform/glx.py
@@ -12,7 +12,7 @@ class GLXPlatform(baseplatform.BasePlatform):
     # references to GL/GLU functions).
     @baseplatform.lazy_property
     def GL(self):
-        for name in ('OpenGL', 'GL'):
+        for name in ('GL', 'OpenGL'):
             try:
                 lib = ctypesloader.loadLibrary(
                     ctypes.cdll, name, mode=ctypes.RTLD_GLOBAL
@@ -42,7 +42,7 @@ class GLXPlatform(baseplatform.BasePlatform):
     @baseplatform.lazy_property
     def GLX(self):
         try:
-            for name in ('GLX', 'OpenGL', 'GL'):
+            for name in ('GLX', 'GL', 'OpenGL'):
                 lib = ctypesloader.loadLibrary(
                     ctypes.cdll, name, mode=ctypes.RTLD_GLOBAL
                 )
@@ -101,7 +101,7 @@ class GLXPlatform(baseplatform.BasePlatform):
     # really kosher...
     @baseplatform.lazy_property
     def GetCurrentContext(self):
-        glXGetCurrentContext = self.GLX.glXGetCurrentContext
+        glXGetCurrentContext = self.GL.glXGetCurrentContext
         glXGetCurrentContext.restype = ctypes.c_void_p
         return glXGetCurrentContext
 


### PR DESCRIPTION
## Summary

This pull request relates to at least 2 open issues:

* https://github.com/mcfletch/pyopengl/issues/113
* https://github.com/mcfletch/pyopengl/issues/104

I first discovered the issue in the Steam OS DevKit Client which depends on PyOpenGL.

In certain Linux X11 environments that load the GLX plugin, the wrong libraries are used for GLX functions. This results in an error related to missing context during application startup. This patch makes this error go away - but I am hesitant to call it a fix. Details follow.

## Reproduction Test Case

Consider a small test program that does nothing useful except trigger the error when attempting to interact with a vertex attribute pointer:

```
import sdl2
import numpy as np
import ctypes
from OpenGL.GL import *

sdl_window = sdl2.SDL_CreateWindow("test".encode('utf-8'),
                                   sdl2.SDL_WINDOWPOS_CENTERED, sdl2.SDL_WINDOWPOS_CENTERED,
                                   320, 240,
                                   sdl2.SDL_WINDOW_OPENGL|sdl2.SDL_WINDOW_RESIZABLE
                                   )
gl_context = sdl2.SDL_GL_CreateContext(sdl_window)
sdl2.SDL_GL_MakeCurrent(sdl_window, gl_context)

vertices = np.array([
    -0.5, -0.5, 0.0,  # Bottom-left
     0.5, -0.5, 0.0,  # Bottom-right
     0.0,  0.5, 0.0   # Top
], dtype=np.float32)
vbo_id = glGenBuffers(1)
glBindBuffer(GL_ARRAY_BUFFER, vbo_id)
glBufferData(GL_ARRAY_BUFFER, vertices.nbytes, vertices, GL_STATIC_DRAW)

vao = glGenVertexArrays(1)
glBindVertexArray(vao)

glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * vertices.itemsize, ctypes.c_void_p(0))
glEnableVertexAttribArray(0)

print("Success")
```

On X11 systems (and maybe even some Wayland systems if my hunch is correct) using any release after 3.1.6, we get this error:

```
UserWarning: Using SDL2 binaries from pysdl2-dll 2.32.0
Traceback (most recent call last):
  File "/home/andrew/source/github.com/mcfletch/pyopengl/fixture.py", line 26, in <module>
    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * vertices.itemsize, ctypes.c_void_p(0))
  File "/home/andrew/source/github.com/mcfletch/pyopengl/OpenGL/latebind.py", line 63, in __call__
    return self.wrapperFunction( self.baseFunction, *args, **named )
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andrew/source/github.com/mcfletch/pyopengl/OpenGL/GL/VERSION/GL_2_0.py", line 469, in glVertexAttribPointer
    contextdata.setValue( key, array )
  File "/home/andrew/source/github.com/mcfletch/pyopengl/OpenGL/contextdata.py", line 58, in setValue
    context = getContext( context )
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/andrew/source/github.com/mcfletch/pyopengl/OpenGL/contextdata.py", line 40, in getContext
    raise error.Error(
OpenGL.error.Error: Attempt to retrieve context when no valid context
```

Once we apply this patch, we succeed, the vertex attribute pointer is received, the window draws, and the program exits zero:

```
UserWarning: Using SDL2 binaries from pysdl2-dll 2.32.0
Success
```

## Details on the fix

For at least some of the affected systems, the issue is due to some changes that apparently happened in recent OpenGL libraries on linux (at least Ubuntu) systems related to the `glXGetCurrentContext` function. The current code, on affected systems, fetches `libGLX.so.0` from `OpenGL.platform.glx.GetCurrentContext()`. This seems like it *SHOULD* work, given that the library in question (at least on my system) exports the context management functions:

```
$ objdump --show-all-symbols -T /usr/lib/x86_64-linux-gnu/libGLX.so | grep -iE 'glX.*Context'
0000000000017bd0 g    DF .text  0000000000000053  Base        glXGetCurrentContext
000000000001b0d0 g    DF .text  000000000000007a  Base        glXQueryContext
000000000001aeb0 g    DF .text  00000000000000b4  Base        glXCreateNewContext
000000000001bca0 g    DF .text  0000000000000082  Base        glXCreateContext
000000000001ae30 g    DF .text  0000000000000074  Base        glXCopyContext
000000000001ada0 g    DF .text  000000000000008e  Base        glXDestroyContext
000000000001b690 g    DF .text  000000000000000f  Base        glXMakeContextCurrent
```

... But for whatever reason, if we allow the calls to go against whatever `GLX()` is returning, we get a failure. The only way I can make this work is to force `OpenGL.platform.glx.glXGetCurrentContext ` to use the `GL()` library instead of `GLX()`, which just makes no sense, because `GLX()` seems like it should work.

Furthermore, on affected systems, the `libOpenGL.so` does *not* provide the context management functions we need! So in addition to forcing `glXGetCurrentContext()` to use `GL()`, we have to force `GL()` to prefer `libGL` instead of `libOpenGL`.

```
$ objdump --show-all-symbols -T /usr/lib/x86_64-linux-gnu/libOpenGL.so.0 | grep -iE 'glX.*Context'

$ objdump --show-all-symbols -T /usr/lib/x86_64-linux-gnu/libGL.so | grep -iE 'glX.*Context'
0000000000045310 g    DF .text  0000000000000011  Base        glXQueryContext
0000000000044450 g    DF .text  0000000000000045  Base        glXFreeContextEXT
0000000000043e20 g    DF .text  0000000000000047  Base        glXCreateAssociatedContextAMD
0000000000044640 g    DF .text  0000000000000011  Base        glXGetCurrentContext
0000000000044ef0 g    DF .text  0000000000000047  Base        glXImportContextEXT
0000000000045330 g    DF .text  000000000000005b  Base        glXQueryContextInfoEXT
0000000000043f60 g    DF .text  0000000000000079  Base        glXCreateContextWithConfigSGIX
00000000000442a0 g    DF .text  000000000000000e  Base        glXDestroyContext
0000000000044250 g    DF .text  0000000000000048  Base        glXDeleteAssociatedContextAMD
0000000000043c70 g    DF .text  000000000000000e  Base        glXCopyContext
0000000000045070 g    DF .text  0000000000000048  Base        glXMakeAssociatedContextCurrentAMD
0000000000044600 g    DF .text  0000000000000034  Base        glXGetCurrentAssociatedContextAMD
00000000000439c0 g    DF .text  00000000000000a7  Base        glXBlitContextFramebufferAMD
0000000000043ed0 g    DF .text  000000000000000e  Base        glXCreateContext
0000000000044560 g    DF .text  0000000000000048  Base        glXGetContextGPUIDAMD
00000000000450c0 g    DF .text  0000000000000011  Base        glXMakeContextCurrent
0000000000043ee0 g    DF .text  0000000000000079  Base        glXCreateContextAttribsARB
0000000000044130 g    DF .text  000000000000000e  Base        glXCreateNewContext
00000000000445b0 g    DF .text  0000000000000048  Base        glXGetContextIDEXT
0000000000043e70 g    DF .text  000000000000005d  Base        glXCreateAssociatedContextAttribsAMD
```

Apparently `libOpenGL.so` is a newer API spec than `libGL.so`, as shown on this Ubuntu system, which could explain the missing methods we need:

```
$ uname -a
Linux wedge 6.8.0-90-generic #91-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 18 14:14:30 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux

$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.3 LTS"

$ dpkg -S /usr/lib/x86_64-linux-gnu/libGL.so.1
libgl1:amd64: /usr/lib/x86_64-linux-gnu/libGL.so.1

$ apt info libgl1
Package: libgl1
Version: 1.7.0-1build1
Priority: extra
Section: libs
Source: libglvnd
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian X Strike Force <debian-x@lists.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 672 kB
Depends: libc6 (>= 2.34), libglvnd0 (= 1.7.0-1build1), libglx0 (= 1.7.0-1build1)
Homepage: https://gitlab.freedesktop.org/glvnd/libglvnd
Task: ubuntu-desktop-minimal, ubuntu-desktop, ubuntu-wsl, ubuntu-desktop-raspi, kubuntu-desktop, xubuntu-minimal, xubuntu-desktop, lubuntu-desktop, ubuntustudio-desktop-core, ubuntustudio-desktop, ubuntukylin-desktop, ubuntukylin-desktop-minimal, ubuntu-mate-core, ubuntu-mate-desktop, ubuntu-budgie-desktop-minimal, ubuntu-budgie-desktop, ubuntu-budgie-desktop-raspi, ubuntu-unity-desktop, edubuntu-desktop-gnome-minimal, edubuntu-desktop-gnome-raspi, ubuntucinnamon-desktop-minimal, ubuntucinnamon-desktop-raspi
Download-Size: 102 kB
APT-Manual-Installed: yes
APT-Sources: http://us.archive.ubuntu.com/ubuntu noble/main amd64 Packages
Description: Vendor neutral GL dispatch library -- legacy GL support
 This is an implementation of the vendor-neutral dispatch layer for
 arbitrating OpenGL API calls between multiple vendors on a per-screen basis.
 .
 This package contains support for old libGL for compatibility reasons.

$ dpkg -S /usr/lib/x86_64-linux-gnu/libOpenGL.so.0
libopengl0:amd64: /usr/lib/x86_64-linux-gnu/libOpenGL.so.0

$ apt info libopengl0
Package: libopengl0
Version: 1.7.0-1build1
Priority: extra
Section: libs
Source: libglvnd
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian X Strike Force <debian-x@lists.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 224 kB
Depends: libc6 (>= 2.34), libglvnd0 (= 1.7.0-1build1)
Homepage: https://gitlab.freedesktop.org/glvnd/libglvnd
Task: ubuntu-desktop-minimal, ubuntu-desktop, ubuntu-desktop-raspi, kubuntu-desktop, xubuntu-minimal, xubuntu-desktop, lubuntu-desktop, ubuntustudio-desktop-core, ubuntustudio-desktop, ubuntukylin-desktop, ubuntukylin-desktop-minimal, ubuntu-mate-core, ubuntu-mate-desktop, ubuntu-budgie-desktop-minimal, ubuntu-budgie-desktop, ubuntu-budgie-desktop-raspi, ubuntu-unity-desktop, edubuntu-desktop-gnome-minimal, edubuntu-desktop-gnome-raspi, ubuntucinnamon-desktop-minimal, ubuntucinnamon-desktop-raspi
Download-Size: 32.8 kB
APT-Manual-Installed: no
APT-Sources: http://us.archive.ubuntu.com/ubuntu noble/main amd64 Packages
Description: Vendor neutral GL dispatch library -- OpenGL support
 This is an implementation of the vendor-neutral dispatch layer for
 arbitrating OpenGL API calls between multiple vendors on a per-screen basis.
 .
 This package contains support for OpenGL.
```

## This is not a good fix

This makes the error go away in at least the `amd64 Ubuntu 24.04` case but I don't think it's the right way to solve the problem. There's got to be a smarter way to handle this than forcibly sending commands back into the legacy OpenGL layer and completely skirting around GLX to go directly to libGL. I don't know OpenGL well enough to immediately see a better resolution and am open to suggestions.